### PR TITLE
timeout option, default 5 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"time"
 )
 
 func main() {
 	var (
 		address, service, certFile string
+		timeout time.Duration
 		conn                       *grpc.ClientConn
 		clientCreds                credentials.TransportCredentials
 		err                        error
@@ -21,6 +23,7 @@ func main() {
 	flag.StringVar(&address, "address", "", "Service address.")
 	flag.StringVar(&service, "service", "", "Service name.")
 	flag.StringVar(&certFile, "certfile", "", "Path to a certificate.")
+	flag.DurationVar(&timeout, "timeout", 5 *time.Second, "Maximum amount of time application will wait for response.")
 	flag.Parse()
 
 	if certFile == "" {
@@ -39,7 +42,10 @@ func main() {
 
 	client := healthpb.NewHealthClient(conn)
 
-	resp, err := client.Check(context.TODO(), &healthpb.HealthCheckRequest{
+	ctx,cancel:= context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{
 		Service: service,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR replaces `context.TODO()` with meaningful context. Also expose new `timeout` flag with default value `5s`. 